### PR TITLE
Commits list use POST instead of GET

### DIFF
--- a/lib/Bitbucket/API/Repositories/Commits.php
+++ b/lib/Bitbucket/API/Repositories/Commits.php
@@ -20,7 +20,7 @@ use Buzz\Message\MessageInterface;
 class Commits extends Api
 {
     /**
-     * Get a list of pull requests
+     * Get a list of commits
      *
      * @access public
      * @param  string           $account The team or individual account owning the repository.


### PR DESCRIPTION
This little contribution to fix commits list request.

As suggested by bitbucket here https://confluence.atlassian.com/display/BITBUCKET/commits+or+commit+Resource#commitsorcommitResource-GETacommitslistforarepositoryorcomparecommitsacrossbranches

Consumers should use GET instead of POST
