### PR TITLE
Pass Pull Request options to Comments when this is called

### DIFF
--- a/lib/Bitbucket/API/Api.php
+++ b/lib/Bitbucket/API/Api.php
@@ -55,11 +55,11 @@ class Api
     /**
      * @param  BuzzClientInterface $client
      */
-    public function __construct(BuzzClientInterface $client = null)
+    public function __construct(BuzzClientInterface $client = null, $options = [])
     {
         // @todo[1]: This exists for keeping BC. To be removed!
         $this->client       = (is_null($client)) ? new Curl : $client;
-        $this->httpClient   = new Client(array(), $client);
+        $this->httpClient   = new Client($options, $client);
 
         $this->httpClient->addListener(new NormalizeArrayListener());
     }
@@ -286,7 +286,7 @@ class Api
      *
      * @throws \InvalidArgumentException
      */
-    protected function childFactory($name)
+    protected function childFactory($name, $options = [])
     {
         if (empty($name)) {
             throw new \InvalidArgumentException('Not child specified.');
@@ -294,7 +294,7 @@ class Api
 
         /** @var Api $child */
         $class = '\\Bitbucket\\API\\'.$name;
-        $child = new $class($this->client);
+        $child = new $class($this->client, $options);
 
         if ($this->getClient()->hasListeners()) {
             $child->getClient()->setListeners($this->getClient()->getListeners());

--- a/lib/Bitbucket/API/Http/Client.php
+++ b/lib/Bitbucket/API/Http/Client.php
@@ -181,6 +181,14 @@ class Client extends ClientListener implements ClientInterface
     {
         return $this->options['api_version'];
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
 
     /**
      * {@inheritDoc}

--- a/lib/Bitbucket/API/Http/ClientInterface.php
+++ b/lib/Bitbucket/API/Http/ClientInterface.php
@@ -123,4 +123,12 @@ interface ClientInterface extends ClientListenerInterface
      * @return string
      */
     public function getApiBaseUrl();
+    
+    /**
+     * Get all Client Options
+     *
+     * @access public
+     * @return array
+     */
+    public function getOptions();
 }

--- a/lib/Bitbucket/API/Repositories/PullRequests.php
+++ b/lib/Bitbucket/API/Repositories/PullRequests.php
@@ -30,7 +30,7 @@ class PullRequests extends API\Api
      */
     public function comments()
     {
-        return $this->childFactory('Repositories\\PullRequests\\Comments');
+        return $this->childFactory('Repositories\\PullRequests\\Comments', $this->getClient()->getOptions());
     }
 
     /**


### PR DESCRIPTION
Hi I have the following code.
```
$options = [
     'base_url'      => 'http://localhost:8180',
];
$bbClient = new \Bitbucket\API\Http\Client($options);
$pullRequest = new \Bitbucket\API\Repositories\PullRequests();
$pullRequest->setClient($bbClient);
$pullRequest->approve($accountName, $repositorySlugName, $issue);
$pullRequest->comments()->create($accountName, $repositorySlugName, $issue, $message);
```
And I notice that the besides the base_url worked on first request It didn't to the second because this library looses the options (it creates a new client).

I'm not sure if this is the right fix so please guide to improve this PR.
