### PR TITLE
Fix get branches api path for 2nd api version

### DIFF
--- a/lib/Bitbucket/API/Repositories/Repository.php
+++ b/lib/Bitbucket/API/Repositories/Repository.php
@@ -212,8 +212,8 @@ class Repository extends API\Api
      */
     public function branches($account, $repo)
     {
-        return $this->requestGet(
-            sprintf('repositories/%s/%s/branches', $account, $repo)
+        return $this->getClient()->setApiVersion('2.0')->get(
+            sprintf('repositories/%s/%s/refs/branches', $account, $repo)
         );
     }
 


### PR DESCRIPTION
Fix get branches api path for 2nd api version (#fix issue "When set version 2 method not work correctly"  t). In most specify frameworks wrappers off your package it leads for error  There is no API hosted at this URL bitbucke