### PR TITLE
Update Repository.php

### DIFF
--- a/lib/Bitbucket/API/Repositories/Repository.php
+++ b/lib/Bitbucket/API/Repositories/Repository.php
@@ -212,8 +212,8 @@ class Repository extends API\Api
      */
     public function branches($account, $repo)
     {
-        return $this->requestGet(
-            sprintf('repositories/%s/%s/branches', $account, $repo)
+        return $this->getClient()->setApiVersion('2.0')->get(
+            sprintf('repositories/%s/%s/refs/branches', $account, $repo)
         );
     }
 


### PR DESCRIPTION
bitbucket api version 2.0 has endpoint "/repositories/{username}/{repo_slug}/refs/branches", the old one is not working