### PR TITLE
Fix for invite users to group.

### DIFF
--- a/docs/examples/users/invitations.md
+++ b/docs/examples/users/invitations.md
@@ -35,7 +35,7 @@ $users->invitations()->group($account_name, 'john', 'testers', 'dummy@example.co
 An invitation is a request sent to an external email address to participate one or more of an account's groups.
 
 ```php
-$users->invitations()->create($account_name, 'john', 'testers', 'dummy@example.com');
+$users->invitations()->create($account_name, 'testers', 'dummy@example.com');
 ```
 
 ### Deletes any pending invitations on a team or individual account for a particular email address.

--- a/lib/Bitbucket/API/Users/Invitations.php
+++ b/lib/Bitbucket/API/Users/Invitations.php
@@ -84,7 +84,7 @@ class Invitations extends Api
     public function create($account, $groupSlug, $email)
     {
         return $this->requestPut(
-            sprintf('users/%s/invitations/', $account),
+            sprintf('users/%s/invitations', $account),
             json_encode([
                 'email' => $email,
                 'group_slug' => $groupSlug

--- a/lib/Bitbucket/API/Users/Invitations.php
+++ b/lib/Bitbucket/API/Users/Invitations.php
@@ -77,15 +77,18 @@ class Invitations extends Api
      *
      * @access public
      * @param  string           $account    The name of an individual or team account.
-     * @param  string           $groupOwner The name of an individual or team account that owns the group.
      * @param  string           $groupSlug  An identifier for the group.
      * @param  string           $email      Name of the email address
      * @return MessageInterface
      */
-    public function create($account, $groupOwner, $groupSlug, $email)
+    public function create($account, $groupSlug, $email)
     {
         return $this->requestPut(
-            sprintf('users/%s/invitations/%s/%s/%s', $account, $email, $groupOwner, $groupSlug)
+            sprintf('users/%s/invitations/', $account),
+            json_encode([
+                'email' => $email,
+                'group_slug' => $groupSlug
+            ])
         );
     }
 

--- a/test/Bitbucket/Tests/API/Users/InvitationsTest.php
+++ b/test/Bitbucket/Tests/API/Users/InvitationsTest.php
@@ -60,7 +60,7 @@ class InvitationsTest extends Tests\TestCase
 
     public function testIssuesNewInvitationSuccess()
     {
-        $endpoint       = 'users/gentle/invitations/dummy@example.com/john/testers';
+        $endpoint       = 'users/gentle/invitations';
         $expectedResult = json_encode('dummy');
 
         $invitations = $this->getApiMock('Bitbucket\API\Users\Invitations');
@@ -70,7 +70,7 @@ class InvitationsTest extends Tests\TestCase
             ->will( $this->returnValue($expectedResult) );
 
         /** @var $invitations \Bitbucket\API\Users\Invitations */
-        $actual = $invitations->create('gentle', 'john', 'testers', 'dummy@example.com');
+        $actual = $invitations->create('gentle', 'testers', 'dummy@example.com');
 
         $this->assertEquals($expectedResult, $actual);
     }


### PR DESCRIPTION
For create method, passing all arguments in path returns an error: Email cannot be in path.
So, some arguments need to be in post body.
More information: https://confluence.atlassian.com/bitbucket/invitations-resource-296911749.html 
 (Section "Issue an invitation to a group") - API V2 follows the same structure.